### PR TITLE
Compile to ES2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es6",
+		"target": "ES2019",
 		"outDir": "out",
 		"lib": [
-			"es6"
+			"ES2019"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
From NodeJS 12 it's safe to compile to `ES2019`. 

https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping

Current target of this extension **1.54** uses NodeJS 14